### PR TITLE
make data safe -only print under debug mode

### DIFF
--- a/UploadFile/Classes/Manager.swift
+++ b/UploadFile/Classes/Manager.swift
@@ -17,7 +17,9 @@ public final class Manager {
                 guard let model = try? responseData.map(UPResponseModel.self) else {
                     return
                 }
+                #if DEBUG
                 print(model.name)
+                #endif 
                 // 接口成功
             } else {
                 // 接口异常


### PR DESCRIPTION
Only debug, show the data in order to debug the application, but when you release the application, it's unnecessary , it makes the application dangerous .